### PR TITLE
Hearthstone history patch (until June 16)

### DIFF
--- a/fireplace/cards/classic/druid.py
+++ b/fireplace/cards/classic/druid.py
@@ -257,7 +257,7 @@ class EX1_164b:
 
 class EX1_169:
 	"""Innervate"""
-	play = ManaThisTurn(CONTROLLER, 2)
+	play = ManaThisTurn(CONTROLLER, 1)
 
 
 class EX1_173:

--- a/fireplace/cards/classic/hunter.py
+++ b/fireplace/cards/classic/hunter.py
@@ -89,7 +89,7 @@ class CS2_084e:
 
 class DS1_183:
 	"""Multi-Shot"""
-	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 2}
+	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 1}
 	play = Hit(RANDOM_ENEMY_MINION * 2, 3)
 
 

--- a/fireplace/cards/classic/neutral_common.py
+++ b/fireplace/cards/classic/neutral_common.py
@@ -67,7 +67,7 @@ EX1_399e = buff(atk=3)
 
 class EX1_508:
 	"""Grimscale Oracle"""
-	update = Refresh(ALL_MINIONS + MURLOC - SELF, buff="EX1_508o")
+	update = Refresh(FRIENDLY_MINIONS + MURLOC - SELF, buff="EX1_508o")
 
 
 EX1_508o = buff(atk=1)

--- a/fireplace/cards/classic/neutral_epic.py
+++ b/fireplace/cards/classic/neutral_epic.py
@@ -20,7 +20,7 @@ class EX1_507:
 	update = Refresh(ALL_MINIONS + MURLOC - SELF, buff="EX1_507e")
 
 
-EX1_507e = buff(+2, +1)
+EX1_507e = buff(atk=2)
 
 
 class EX1_564:

--- a/fireplace/cards/classic/neutral_epic.py
+++ b/fireplace/cards/classic/neutral_epic.py
@@ -17,7 +17,7 @@ class EX1_105:
 
 class EX1_507:
 	"""Murloc Warleader"""
-	update = Refresh(ALL_MINIONS + MURLOC - SELF, buff="EX1_507e")
+	update = Refresh(FRIENDLY_MINIONS + MURLOC - SELF, buff="EX1_507e")
 
 
 EX1_507e = buff(atk=2)

--- a/fireplace/cards/classic/neutral_rare.py
+++ b/fireplace/cards/classic/neutral_rare.py
@@ -124,7 +124,7 @@ class EX1_097:
 
 class EX1_103:
 	"""Coldlight Seer"""
-	play = Buff(ALL_MINIONS + MURLOC - SELF, "EX1_103e")
+	play = Buff(FRIENDLY_MINIONS + MURLOC - SELF, "EX1_103e")
 
 
 EX1_103e = buff(health=2)

--- a/fireplace/cards/classic/priest.py
+++ b/fireplace/cards/classic/priest.py
@@ -72,7 +72,7 @@ EX1_623e = buff(health=3)
 class CS2_004:
 	"""Power Word: Shield"""
 	requirements = {PlayReq.REQ_MINION_TARGET: 0, PlayReq.REQ_TARGET_TO_PLAY: 0}
-	play = Buff(TARGET, "CS2_004e"), Draw(CONTROLLER)
+	play = Buff(TARGET, "CS2_004e")
 
 
 CS2_004e = buff(health=2)
@@ -80,7 +80,7 @@ CS2_004e = buff(health=2)
 
 class CS1_112:
 	"""Holy Nova"""
-	play = Hit(ENEMY_CHARACTERS, 2), Heal(FRIENDLY_CHARACTERS, 2)
+	play = Hit(ENEMY_MINIONS, 2), Heal(FRIENDLY_CHARACTERS, 2)
 
 
 class CS1_113:
@@ -109,7 +109,7 @@ class CS1_129e:
 class CS1_130:
 	"""Holy Smite"""
 	requirements = {PlayReq.REQ_TARGET_TO_PLAY: 0}
-	play = Hit(TARGET, 2)
+	play = Hit(TARGET, 3)
 
 
 class CS2_003:

--- a/fireplace/cards/classic/rogue.py
+++ b/fireplace/cards/classic/rogue.py
@@ -178,7 +178,7 @@ class EX1_145:
 
 
 class EX1_145o:
-	update = Refresh(FRIENDLY_HAND + SPELL, {GameTag.COST: -3})
+	update = Refresh(FRIENDLY_HAND + SPELL, {GameTag.COST: -2})
 	events = OWN_SPELL_PLAY.on(Destroy(SELF))
 
 

--- a/fireplace/cards/classic/shaman.py
+++ b/fireplace/cards/classic/shaman.py
@@ -163,7 +163,7 @@ class EX1_248:
 
 class EX1_251:
 	"""Forked Lightning"""
-	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 2}
+	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 1}
 	play = Hit(RANDOM_ENEMY_MINION * 2, 2)
 
 

--- a/fireplace/cards/classic/warlock.py
+++ b/fireplace/cards/classic/warlock.py
@@ -187,5 +187,8 @@ EX1_596e = buff(+2, +2)
 
 class NEW1_003:
 	"""Sacrificial Pact"""
-	requirements = {PlayReq.REQ_TARGET_TO_PLAY: 0, PlayReq.REQ_TARGET_WITH_RACE: 15}
+	requirements = {
+		PlayReq.REQ_FRIENDLY_TARGET: 0,
+		PlayReq.REQ_TARGET_IF_AVAILABLE: 0,
+		PlayReq.REQ_TARGET_WITH_RACE: 15}
 	play = Destroy(TARGET), Heal(FRIENDLY_HERO, 5)

--- a/fireplace/cards/classic/warrior.py
+++ b/fireplace/cards/classic/warrior.py
@@ -102,7 +102,7 @@ class CS2_108:
 
 class CS2_114:
 	"""Cleave"""
-	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 2}
+	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 1}
 	play = Hit(RANDOM_ENEMY_MINION * 2, 2)
 
 

--- a/fireplace/cards/gangs/priest.py
+++ b/fireplace/cards/gangs/priest.py
@@ -10,7 +10,7 @@ class CFM_020:
 
 
 class CFM_020e:
-	update = Refresh(FRIENDLY_HERO_POWER, {GameTag.COST: SET(1)})
+	update = Refresh(FRIENDLY_HERO_POWER, {GameTag.COST: SET(0)})
 
 
 class CFM_605:

--- a/fireplace/cards/gvg/priest.py
+++ b/fireplace/cards/gvg/priest.py
@@ -30,7 +30,7 @@ class GVG_014a:
 
 class GVG_072:
 	"""Shadowboxer"""
-	events = Heal().on(Hit(RANDOM_ENEMY_CHARACTER, 1))
+	events = Heal(ALL_MINIONS).on(Hit(RANDOM_ENEMY_CHARACTER, 1))
 
 
 class GVG_083:

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -119,7 +119,7 @@ class KAR_069:
 
 class KAR_070:
 	"""Ethereal Peddler"""
-	play = Buff(FRIENDLY_HAND - ROGUE, "KAR_070e")
+	play = Buff(FRIENDLY_HAND + OTHER_CLASS_CHARACTER, "KAR_070e")
 
 
 @custom_card

--- a/fireplace/cards/tgt/warlock.py
+++ b/fireplace/cards/tgt/warlock.py
@@ -61,5 +61,5 @@ AT_024e = buff(+3, +3)
 
 class AT_025:
 	"""Dark Bargain"""
-	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 2}
+	requirements = {PlayReq.REQ_MINIMUM_ENEMY_MINIONS: 1}
 	play = Destroy(RANDOM(ENEMY_MINIONS) * 2), Discard(RANDOM(FRIENDLY_HAND) * 2)

--- a/fireplace/cards/tgt/warlock.py
+++ b/fireplace/cards/tgt/warlock.py
@@ -6,7 +6,11 @@ from ..utils import *
 
 class AT_019:
 	"""Dreadsteed"""
-	deathrattle = Summon(CONTROLLER, "AT_019")
+	deathrattle = Buff(CONTROLLER, "AT_019e")
+
+
+class AT_019e:
+	events = OWN_TURN_END.on(Summon(CONTROLLER, "AT_019"), Destroy(SELF))
 
 
 class AT_021:

--- a/fireplace/cards/wog/neutral_legendary.py
+++ b/fireplace/cards/wog/neutral_legendary.py
@@ -59,8 +59,7 @@ class OG_134:
 	def play(self):
 		amount = min(self.controller.times_spell_played_this_game, 30)
 		for i in range(amount):
-			if (self.zone == Zone.PLAY) and (not self.silenced):
-				yield CastSpell(RandomSpell())
+			yield CastSpell(RandomSpell())
 
 
 class OG_280:

--- a/fireplace/dsl/selector.py
+++ b/fireplace/dsl/selector.py
@@ -216,7 +216,7 @@ class SetOpSelector(Selector):
 
 	@staticmethod
 	def _entity_id_set(entities: Iterable[BaseEntity]) -> Set[BaseEntity]:
-		return set(e.entity_id for e in entities if e)
+		return set(e.entity_id for e in entities if hasattr(e, "entity_id"))
 
 	def eval(self, entities, source):
 		left_children = self.left.eval(entities, source)

--- a/fireplace/dsl/selector.py
+++ b/fireplace/dsl/selector.py
@@ -478,3 +478,19 @@ RANDOM_ENEMY_CHARACTER = RANDOM(ENEMY_CHARACTERS - MORTALLY_WOUNDED)
 
 DAMAGED_CHARACTERS = ALL_CHARACTERS + DAMAGED
 CTHUN = FRIENDLY + ID("OG_280")
+
+FRIENDLY_CLASS_CHARACTER = FuncSelector(
+	lambda entities, src: [
+		e for e in entities
+		if hasattr(e, "card_class") and hasattr(e, "controller") and
+		e.card_class == e.controller.hero.card_class
+	]
+)
+OTHER_CLASS_CHARACTER = FuncSelector(
+	lambda entities, src: [
+		e for e in entities
+		if hasattr(e, "card_class") and hasattr(e, "controller") and
+		e.card_class != CardClass.NEUTRAL and e.card_class != CardClass.DREAM and
+		e.card_class != e.controller.hero.card_class
+	]
+)

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -1328,6 +1328,7 @@ def test_felguard():
 def test_felguard_negative_mana():
 	game = prepare_game(game_class=Game)
 	game.player1.give(INNERVATE).play()
+	game.player1.give(INNERVATE).play()
 	assert game.player1.max_mana == 1
 	assert game.player1.mana == 3
 	game.player1.give("EX1_301").play()

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -1476,7 +1476,7 @@ def test_grimscale_oracle():
 	assert murloc2.atk == 1
 	grimscale.play()
 	assert murloc1.atk == 1 + 1
-	assert murloc2.atk == 1 + 1
+	assert murloc2.atk == 1
 	assert grimscale.atk == 1
 
 	game.player1.give(TIME_REWINDER).play(target=grimscale)

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -675,11 +675,19 @@ def test_cleave():
 	assert cleave.is_playable()
 	cleave.play()
 	assert len(game.current_player.opponent.field) == 0
-	game.current_player.give(WISP).play()
+	bearer = game.current_player.give("EX1_405").play()
 	game.end_turn()
 
-	cleave2 = game.player1.give("CS2_114")
-	assert not cleave2.is_playable()
+	cleave2 = game.current_player.give("CS2_114")
+	# Patch 14.6 multi-target cards to function even if
+	# there is only one viable target on the board
+	assert cleave2.is_playable()
+	cleave2.play()
+	assert bearer.health == 2
+	game.end_turn()
+
+	cleave3 = game.current_player.give("CS2_114")
+	assert not cleave3.is_playable()
 
 
 def test_cold_blood():

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -2553,18 +2553,18 @@ def test_preparation():
 	assert game.player1.used_mana == 0
 	assert prep2.cost == prep3.cost == 0
 	assert smite.cost == 0
-	assert fireball.cost == 4 - 3
+	assert fireball.cost == 4 - 2
 	assert fireball2.cost == 4
 	assert footman.cost == footman2.cost == 1
 	prep2.play()
 	assert game.player1.used_mana == 0
 	assert prep2.cost == prep3.cost == 0
 	assert smite.cost == 0
-	assert fireball.cost == 4 - 3
+	assert fireball.cost == 4 - 2
 	assert fireball2.cost == 4
 	assert footman.cost == footman2.cost == 1
 	fireball.play(target=game.player2.hero)
-	assert game.player1.used_mana == 1
+	assert game.player1.used_mana == 2
 	assert smite.cost == 1
 	assert fireball2.cost == 4
 	assert footman.cost == footman2.cost == 1

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -2518,7 +2518,6 @@ def test_power_word_shield():
 	pwshield = game.player1.give("CS2_004")
 	pwshield.play(target=wisp)
 	assert wisp.health == 3
-	assert len(game.player1.hand) == 1
 	game.player1.give(SILENCE).play(target=wisp)
 	assert wisp.health == 1
 

--- a/tests/test_gvg.py
+++ b/tests/test_gvg.py
@@ -366,11 +366,11 @@ def test_gazlowe():
 def test_gazlowe_preparation():
 	game = prepare_empty_game()
 	game.player1.give("GVG_117").play()
-	fireball = game.player1.give("CS2_029")
-	assert fireball.cost == 4
+	drainlife = game.player1.give("CS2_061")
+	assert drainlife.cost == 3
 	game.player1.give("EX1_145").play()
-	assert fireball.cost == 1
-	fireball.play(target=game.player2.hero)
+	assert drainlife.cost == 1
+	drainlife.play(target=game.player2.hero)
 	assert len(game.player1.hand) == 1
 	assert game.player1.hand[0].race == Race.MECHANICAL
 

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -219,16 +219,29 @@ def test_swashburglar():
 
 
 def test_ethereal_peddler():
-	game = prepare_empty_game()
-	game.player1.discard_hand()
-	mc = game.player1.give(MIND_CONTROL)
-	evis = game.player1.give("EX1_124")  # Eviscerate
+	game = prepare_empty_game(CardClass.ROGUE, CardClass.PRIEST)
+	if game.current_player.hero.card_class == CardClass.ROGUE:
+		game.end_turn()
+
+	game.current_player.discard_hand()
+	mc = game.current_player.give(MIND_CONTROL)
+	evis = game.current_player.give("EX1_124")  # Eviscerate
 	assert mc.cost == 10
 	assert evis.cost == 2
-	game.player1.give("KAR_070").play()
+	game.current_player.give("KAR_070").play()
+	assert mc.cost == 10
+	assert evis.cost == 0
+	game.end_turn()
 
-	assert mc.cost == 8
-	assert evis.cost == 2
+	game.current_player.discard_hand()
+	mc2 = game.current_player.give(MIND_CONTROL)
+	evis2 = game.current_player.give("EX1_124")  # Eviscerate
+	assert mc2.cost == 10
+	assert evis2.cost == 2
+	game.current_player.give("KAR_070").play()
+	assert game.current_player.hero.card_class
+	assert mc2.cost == 8
+	assert evis2.cost == 2
 
 
 def test_malchezaars_imp():

--- a/tests/test_league.py
+++ b/tests/test_league.py
@@ -172,7 +172,7 @@ def test_djinni_of_zephyrs():
 	pwshield.play(target=statue)
 	statue.max_health == 10 + 2
 	djinni.max_health == 6 + 2
-	assert len(game.player1.hand) == 1 + 1
+	assert len(game.player1.hand) == 0
 
 	# Djinni can trigger on minions that are "dead" (eg. killed by the spell)
 	naturalize = game.player1.give("EX1_161")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,25 +2,16 @@ from utils import *
 
 
 def test_event_queue_heal():
-	"""
-	Test the event queue for mass hits.
-	Events are supposed to be processed in two phases:
-	1. Event queuing
-	2. Triggers (in order of play)
-	This means that playing a Refreshment Vendor on a board with a
-	Shadowboxer, and two heroes damaged by 1 will result in the enemy
-	hero being damaged by 28. Shadowboxer will trigger twice, after
-	both heals have triggered.
-	"""
 	game = prepare_game()
-	game.player1.give(MOONFIRE).play(target=game.player1.hero)
-	game.player1.give(MOONFIRE).play(target=game.player2.hero)
-	shadowboxer = game.player1.give("GVG_072")
-	shadowboxer.play()
-	vendor = game.player1.give("AT_111")
-	vendor.play()
-	assert game.player1.hero.health == 30
-	assert game.player2.hero.health == 28
+	shadowboxer1 = game.player1.give("GVG_072")
+	shadowboxer1.play()
+	shadowboxer2 = game.player1.give("GVG_072")
+	shadowboxer2.play()
+	game.player1.give(MOONFIRE).play(target=shadowboxer1)
+	game.player1.give(MOONFIRE).play(target=shadowboxer2)
+	circle = game.player1.give("EX1_621")
+	circle.play()
+	assert game.player2.hero.health == 26
 
 
 def test_event_queue_summon():

--- a/tests/test_tgt.py
+++ b/tests/test_tgt.py
@@ -33,6 +33,8 @@ def test_astral_communion():
 	astral = game.player1.give("AT_043")
 	game.player1.give(INNERVATE).play()
 	game.player1.give(INNERVATE).play()
+	game.player1.give(INNERVATE).play()
+	game.player1.give(INNERVATE).play()
 	for i in range(5):
 		game.player1.give(WISP)
 	assert game.player1.max_mana == 1

--- a/tests/test_tgt.py
+++ b/tests/test_tgt.py
@@ -232,6 +232,8 @@ def test_dreadsteed():
 	assert len(game.player1.field) == 1
 	game.player1.give(MOONFIRE).play(target=dreadsteed)
 	assert dreadsteed.dead
+	assert len(game.player1.field) == 0
+	game.end_turn()
 	assert len(game.player1.field) == 1
 
 


### PR DESCRIPTION
- Patch 17.0 (Priest remake)
- Patch 16.6 (Yogg-Saron and Raza revert)
- Patch 14.6 (mulit-target cards)
- Patch 14.2.2 (Preparation reduces cost 2)
- Patch 17.0.2 (Sacrificial Pact only affect frienly demons)
- Patch 12.0 (Shadowboxer only trigger when minions healed)
- Patch 9.1.0 (Innervate gain 1 mana; Murloc Warleader will not +1 health)
- Patch 9.0 (Deathsteed summon at the end of the turn)
- Patch 11.0 (Ethereal Peddler affect another class)
- Patch 6.2 (Murloc only affect firendly)